### PR TITLE
Fix for gpioactor

### DIFF
--- a/cbpi/extension/gpioactor/__init__.py
+++ b/cbpi/extension/gpioactor/__init__.py
@@ -19,6 +19,9 @@ except Exception:
     patcher.start()
     import RPi.GPIO as GPIO
 
+mode = GPIO.getmode()
+if (mode == None):
+    GPIO.setmode(GPIO.BCM)
 
 @parameters([Property.Select(label="GPIO", options=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27]), Property.Select(label="Inverted", options=["Yes", "No"],description="No: Active on high; Yes: Active on low")])
 class GPIOActor(CBPiActor):


### PR DESCRIPTION
Currently, gpioactor is not working on a raspberryPi.
This fixes issue#15
definition of mode --> GPIO.BCM