### PR TITLE
Fix OneWire Setup

### DIFF
--- a/cbpi/cli.py
+++ b/cbpi/cli.py
@@ -67,7 +67,7 @@ def create_home_folder_structure():
 
 def setup_one_wire():
     print("Setting up 1Wire")
-    with open('/boot/config.txt', 'wb') as f:
+    with open('/boot/config.txt', 'w') as f:
         f.write("dtoverlay=w1-gpio,gpiopin=4,pullup=on")
     print("/boot/config.txt created")
 


### PR DESCRIPTION
Fix incorrect permissions for OneWire setup

Error:
```
pi@raspberrypi:/ $ sudo cbpi onewire --setup
Setting up 1Wire
Traceback (most recent call last):
  File "/usr/local/bin/cbpi", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/cbpi/cli.py", line 238, in onewire
    setup_one_wire()
  File "/usr/local/lib/python3.7/dist-packages/cbpi/cli.py", line 71, in setup_one_wire
    f.write("dtoverlay=w1-gpio,gpiopin=4,pullup=on")
TypeError: a bytes-like object is required, not 'str'
```

After fix:
```
pi@raspberrypi:/ $ sudo cbpi onewire --setup
Setting up 1Wire
/boot/config.txt created

pi@raspberrypi:/ $ cat /boot/config.txt 
dtoverlay=w1-gpio,gpiopin=4,pullup=onpi@raspberrypi:/ $ 
```