### PR TITLE
enforce python3 via Setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(name='cbpi',
       '': ['*.txt', '*.rst', '*.yaml'],
       'cbpi': ['*','*.txt', '*.rst', '*.yaml']},
 
+      python_requires='>=3',
+
       install_requires=[
           "aiohttp==3.7.4",
           "aiohttp-auth==0.1.1",


### PR DESCRIPTION
enforcing the python version should prevent further pseudo issues like  #36 and #49 - at least  from pip versions newer then 9

please adjust version to whatever you think makes sense