### PR TITLE
fixes KBH import hop times

### DIFF
--- a/cbpi/controller/upload_controller.py
+++ b/cbpi/controller/upload_controller.py
@@ -193,7 +193,7 @@ class UploadController:
                     pass
 
                 # get the hop addition times
-                c.execute('SELECT Zeit FROM Hopfengaben WHERE Vorderwuerze = 0 AND SudID = ?', (Recipe_ID,))
+                c.execute('SELECT Zeit FROM Hopfengaben WHERE Vorderwuerze <> 1 AND SudID = ?', (Recipe_ID,))
                 hops = c.fetchall()
 
                 # get the misc addition times


### PR DESCRIPTION
fixes #100 

my test recipe looks like this:
![grafik](https://user-images.githubusercontent.com/4346028/184032599-87114c41-1168-4c2b-b6f9-8478b2c77ded.png)
and the relevant part of the resulting sqlite table looks like this:
![grafik](https://user-images.githubusercontent.com/4346028/184032755-5577b9ab-07fa-4193-8e5a-d2f1c24e0d41.png)
If you look at the column `Vorderwuerze` you see that there are different Values possible then 0 or 1. From my testing and understanding it should work like this:

1. Vorderwürze=pre_boil=1
2. Kochbeginn=boil_start=2
3. Kochen=boiling=3
4. Kochende=boiling_finish=4
5.  Ausschlag=Wirlpool=5

Since the time value is still provided i hope i can just differentiate between Vorderwürze=1 and all others <> 1 to create the intended result.

With my test recipe it seems to work out great:
![grafik](https://user-images.githubusercontent.com/4346028/184037903-8936556d-875f-4045-bb67-7ebd11b46782.png)

EDIT:
I tested the negative hop timer value for Whirlpool additions and the notification is of course missing. Alle the other notifications came as expected so i guess this still fixes the issue at hand.